### PR TITLE
Add new line after element written

### DIFF
--- a/gpx/Writer.cpp
+++ b/gpx/Writer.cpp
@@ -140,7 +140,7 @@ namespace gpx
 
     if (level >= 0)
     {
-      cout << endl;
+      stream << endl;
     }
 
     return stream.good();


### PR DESCRIPTION
Currently when using `writer()` with prettyPrint=True the output indents the file properly, but doesn't add a newline at the end resulting in a sort of pretty print output. 

Example:
```<?xml version="1.0" encoding="UTF-8"?>
<gpx version="1.1">
 <trk>
  <trkseg>
   <trkpt lon="XX.683136257" lat="XX.220189133"></trkpt>   <trkpt lon="XX.683129019" lat="XX.220189767"></trkpt>   <trkpt lon="XX.683118630" lat="XX.220184664"></trkpt>   <trkpt lon="XX.683117661" lat="XX.220181373"></trkpt>   <trkpt lon="XX.683121000" lat="XX.220170225"></trkpt>   <trkpt lon="XX.683124541" lat="XX.220166326"></trkpt>   <trkpt lon="XX.683135889" lat="XX.220160829"></trkpt>   <trkpt lon="XX.683146985" lat="XX.220161169"></trkpt>   <trkpt lon="XX.683154262" lat="XX.220166257"></trkpt>  </trkseg> </trk></gpx>
```

This PR adds a `\n` after each element is written. 
```<?xml version="1.0" encoding="UTF-8"?>
<gpx version="1.1">
 <trk>
  <trkseg>
   <trkpt lon="XX.683136257" lat="XX.220189133"></trkpt>
   <trkpt lon="XX.683129019" lat="XX.220189767"></trkpt>
   <trkpt lon="XX.683118630" lat="XX.220184664"></trkpt>
   <trkpt lon="XX.683117661" lat="XX.220181373"></trkpt>
   <trkpt lon="XX.683121000" lat="XX.220170225"></trkpt>
   <trkpt lon="XX.683124541" lat="XX.220166326"></trkpt>
   <trkpt lon="XX.683135889" lat="XX.220160829"></trkpt>
   <trkpt lon="XX.683146985" lat="XX.220161169"></trkpt>
   <trkpt lon="XX.683154262" lat="XX.220166257"></trkpt>
  </trkseg>
 </trk>
</gpx>
```

Thought it doesn't modify or invalidate the GPX file itself, it makes it easy on the eyes. There might be issues with the `\n` for linux vs windows platforms etc. I am open to the best way to handle that if this is an issue.