### PR TITLE
Accumulate character data across multiple handler invocations

### DIFF
--- a/gpx/Node.h
+++ b/gpx/Node.h
@@ -117,7 +117,14 @@ namespace gpx
     /// @param value   the value of the attribute or element
     ///
     virtual void setValue(std::string value) { _value = value; }
-    
+
+    ///
+    /// Append to the value of the element
+    ///
+    /// @param value   the value to append to the attribute or element
+    ///
+    virtual void appendValue(const std::string& value) { _value.append(value); }
+
     ///
     /// Get the parent node of this node
     ///

--- a/gpx/Parser.cpp
+++ b/gpx/Parser.cpp
@@ -113,7 +113,7 @@ namespace gpx
   {
     if (_current != 0)
     {
-      _current->setValue(value);
+      _current->appendValue(value);
     }
     else if (_report != 0)
     {
@@ -245,7 +245,7 @@ namespace gpx
     Parser *self = static_cast<Parser*>(userData);
     
     string data(s, len);
-    
+
     self->value(data);
   }
 


### PR DESCRIPTION
I hit an issue when parsing from an istream from an 88k file. In my case the trkpt time elements were occasionally wrong, in that they were missing the head of the string. I was able to observe the same behaviour when running the gpxtrk example.

After some digging I found that the behaviour was dependent on the size of the fixed size buffer in `Parser::parse(std::istream &stream)` https://github.com/irdvo/gpxlib/blob/master/gpx/Parser.cpp#L176. I expect it affects any > 4k file and occurs at the 4k boundaries, but haven't confirmed it.

The expat docs list character data being split across multiple handler calls as a common pitfall https://libexpat.github.io/doc/common-pitfalls/#split-character-data

This change accumulates character data across multiple invocations by adding an `appendValue` to `Node` and calling that from `Parser`. This has fixed the problem for me in both my code and the gpxtrk example, but there's likely a better approach.

I'm running libexpat 2.2.5 from the Ubuntu 18.04 distribution in case it helps.