### PR TITLE
Modify find expat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,40 @@
-project(gpx)
-
 cmake_minimum_required(VERSION 2.8.0)
 
-set (gpx_VERSION_MAJOR 0)
-set (gpx_VERSION_MINOR 1)
-set (gpx_VERSION_MICRO 1)
+project(gpx)
+
+SET(BUILD_VERSION "v0.0.1")
+# Find Git Version Patch
+IF(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    if(NOT GIT)
+        SET(GIT $ENV{GIT})
+    endif()
+    if(NOT GIT)
+        FIND_PROGRAM(GIT NAMES git git.exe git.cmd)
+    endif()
+    IF(GIT)
+        EXECUTE_PROCESS(
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMAND ${GIT} describe --tags
+            OUTPUT_VARIABLE GIT_VERSION  OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+	    if(NOT GIT_VERSION)
+            EXECUTE_PROCESS(
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                COMMAND ${GIT} rev-parse --short HEAD
+                OUTPUT_VARIABLE GIT_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+        endif()
+        SET(BUILD_VERSION ${GIT_VERSION})
+    ENDIF()
+ENDIF()
+message("BUILD_VERSION:${BUILD_VERSION}")
+
+CONFIGURE_FILE(
+    "${CMAKE_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+ADD_CUSTOM_TARGET(uninstall
+    "${CMAKE_COMMAND}" -P "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake")
 
 add_subdirectory(gpx)
 option(BUILD_EXAMPLES "Build examples" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,14 @@ set (gpx_VERSION_MINOR 1)
 set (gpx_VERSION_MICRO 1)
 
 add_subdirectory(gpx)
-add_subdirectory(examples)
-add_subdirectory(test)
+option(BUILD_EXAMPLES "Build examples" ON)
+if(BUILD_EXAMPLES)
+	add_subdirectory(examples)
+endif(BUILD_EXAMPLES)
+option(BUILD_TESTS "Build tests" ON)
+if(BUILD_TESTS)
+	add_subdirectory(test)
+endif()
 
 install(DIRECTORY gpx/ DESTINATION include/gpx FILES_MATCHING PATTERN "*.h" PATTERN "CMakeFiles" EXCLUDE)
 

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,23 @@
+
+IF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+    MESSAGE(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
+ENDIF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+FILE(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+STRING(REGEX REPLACE "\n" ";" files "${files}")
+FOREACH(file ${files})
+    MESSAGE(STATUS "Uninstalling \"${file}\"")
+    IF(EXISTS "${file}")
+        EXEC_PROGRAM(
+            "@CMAKE_COMMAND@" ARGS "-E remove \"${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+            )
+        IF("${rm_retval}" STREQUAL 0)
+        ELSE("${rm_retval}" STREQUAL 0)
+            MESSAGE(FATAL_ERROR "Problem when removing \"${file}\"")
+        ENDIF("${rm_retval}" STREQUAL 0)
+    ELSE(EXISTS "${file}")
+        MESSAGE(STATUS "File \"${file}\" does not exist.")
+    ENDIF(EXISTS "${file}")
+ENDFOREACH(file)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,11 +1,6 @@
-#if(WIN32)
-#  set(EXPAT_FOUND TRUE)
-#  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
-#  set(EXPAT_LIBRARIES    "/Program Files (x86)/Expat 2.2.0/Bin/libexpat")
-  # Copy libexpat.dll and test.gpx to executable directory
-#else()
-  find_package(EXPAT REQUIRED)
-#endif()
+cmake_minimum_required(VERSION 2.8.0)
+
+find_package(EXPAT REQUIRED)
 
 include_directories (. .. ${EXPAT_INCLUDE_DIRS})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,11 +1,11 @@
-if(WIN32)
-  set(EXPAT_FOUND TRUE)
-  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
-  set(EXPAT_LIBRARIES    "/Program Files (x86)/Expat 2.2.0/Bin/libexpat")
+#if(WIN32)
+#  set(EXPAT_FOUND TRUE)
+#  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
+#  set(EXPAT_LIBRARIES    "/Program Files (x86)/Expat 2.2.0/Bin/libexpat")
   # Copy libexpat.dll and test.gpx to executable directory
-else()
+#else()
   find_package(EXPAT REQUIRED)
-endif()
+#endif()
 
 include_directories (. .. ${EXPAT_INCLUDE_DIRS})
 

--- a/gpx/CMakeLists.txt
+++ b/gpx/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 2.8.0)
 
-project(gpx)
-
 find_package(EXPAT REQUIRED)
 
 include_directories (. .. ${EXPAT_INCLUDE_DIRS})
@@ -48,13 +46,13 @@ if(BUILD_SHARED_LIBS)
     endif()
 endif()
 
-add_library(gpx ${SRC})
-target_link_libraries(gpx ${EXPAT_LIBRARIES})
+add_library(${PROJECT_NAME} ${SRC})
+target_link_libraries(${PROJECT_NAME} ${EXPAT_LIBRARIES})
 
-set_target_properties(gpx PROPERTIES VERSION   1)
-set_target_properties(gpx PROPERTIES SOVERSION 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${BUILD_VERSION})
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${BUILD_VERSION})
 
-install(TARGETS gpx RUNTIME DESTINATION bin
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin
                     LIBRARY DESTINATION lib
                     ARCHIVE DESTINATION lib)
 

--- a/gpx/CMakeLists.txt
+++ b/gpx/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 2.8.0)
 
-if(WIN32)
-  set(EXPAT_FOUND TRUE)
-  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
-else()
+#if(WIN32)
+#  set(EXPAT_FOUND TRUE)
+#  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
+#else()
   find_package(EXPAT REQUIRED)
-endif()
+#endif()
 
 include_directories (. .. ${EXPAT_INCLUDE_DIRS})
 
@@ -43,17 +43,7 @@ set(SRC
     ReportCerr.cpp
     )
 
-
-# SHARED or STATIC
-if(WIN32)
-  add_library(gpx
-              STATIC
-              ${SRC})
-else()
-  add_library(gpx
-              SHARED
-              ${SRC})
-endif()
+add_library(gpx ${SRC})
 
 set_target_properties(gpx PROPERTIES VERSION   1)
 set_target_properties(gpx PROPERTIES SOVERSION 1)

--- a/gpx/CMakeLists.txt
+++ b/gpx/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 2.8.0)
 
-#if(WIN32)
-#  set(EXPAT_FOUND TRUE)
-#  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
-#else()
-  find_package(EXPAT REQUIRED)
-#endif()
+project(gpx)
+
+find_package(EXPAT REQUIRED)
 
 include_directories (. .. ${EXPAT_INCLUDE_DIRS})
 
@@ -43,7 +40,16 @@ set(SRC
     ReportCerr.cpp
     )
 
+option(BUILD_SHARED_LIBS "Build shared library" ON)
+if(BUILD_SHARED_LIBS)
+    add_definitions(-DBUILD_SHARED_LIBS)
+    if(WIN32)
+        add_definitions(-DDLL_EXPORT)
+    endif()
+endif()
+
 add_library(gpx ${SRC})
+target_link_libraries(gpx ${EXPAT_LIBRARIES})
 
 set_target_properties(gpx PROPERTIES VERSION   1)
 set_target_properties(gpx PROPERTIES SOVERSION 1)

--- a/gpx/Extensions.h
+++ b/gpx/Extensions.h
@@ -27,6 +27,7 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include "gpx/String_.h"
 
 
@@ -38,7 +39,7 @@ namespace gpx
   /// @brief The extensions class.
   ///
   
-  class Extensions : public String
+  class DLL_API Extensions : public String
   {
     public:
 

--- a/gpx/GPX.h
+++ b/gpx/GPX.h
@@ -27,6 +27,7 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include "gpx/Node.h" 
 
 #include "gpx/String_.h"
@@ -65,7 +66,7 @@ namespace gpx
   /// @brief The root node of a GPX document
   ///
 
-  class GPX : public Node
+  class DLL_API GPX : public Node
   {
   public:
 

--- a/gpx/List.h
+++ b/gpx/List.h
@@ -30,7 +30,7 @@
 #include <list>
 
 #include "gpx/Node.h"
-
+#include "gpx/export.h"
 
 namespace gpx
 {
@@ -41,7 +41,7 @@ namespace gpx
   ///
   
   template<class T>
-  class List : public Node
+  class DLL_API List : public Node
   {
     public:
 

--- a/gpx/Metadata.h
+++ b/gpx/Metadata.h
@@ -27,6 +27,7 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include "gpx/Node.h"
 
 #include "gpx/String_.h"
@@ -46,7 +47,7 @@ namespace gpx
   /// @brief The metadata from another schema's class.
   ///
   
-  class Metadata : public Node
+  class DLL_API Metadata : public Node
   {
     public:
 

--- a/gpx/Node.h
+++ b/gpx/Node.h
@@ -35,6 +35,8 @@
 #define strcasecmp _stricmp
 #endif
 #pragma warning(disable:4355)
+#pragma warning(disable:4251)
+#pragma warning(disable:4275)
 #endif
 
 #ifdef __linux__

--- a/gpx/Parser.h
+++ b/gpx/Parser.h
@@ -41,7 +41,7 @@ namespace gpx
   /// @brief The xml parser class.
   ///
   
-  class Parser
+  class DLL_API Parser
   {
   public:
 

--- a/gpx/RTE.h
+++ b/gpx/RTE.h
@@ -27,6 +27,7 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include "gpx/Node.h"
 
 #include "gpx/String_.h"
@@ -45,7 +46,7 @@ namespace gpx
   /// @brief The route class.
   ///
   
-  class RTE : public Node
+  class DLL_API RTE : public Node
   {
     public:
 

--- a/gpx/Report.h
+++ b/gpx/Report.h
@@ -27,6 +27,7 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include <string>
 
 namespace gpx
@@ -39,7 +40,7 @@ namespace gpx
   /// @brief The report interface for reporting warnings
   ///
   
-  class Report
+  class DLL_API Report
   {
     public:
 

--- a/gpx/ReportCerr.h
+++ b/gpx/ReportCerr.h
@@ -27,6 +27,7 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include "gpx/Report.h"
 
 namespace gpx
@@ -37,7 +38,7 @@ namespace gpx
   /// @brief The report on cerr class for reporting warnings
   ///
   
-  class ReportCerr : public Report
+  class DLL_API ReportCerr : public Report
   {
     public:
 

--- a/gpx/String_.h
+++ b/gpx/String_.h
@@ -27,8 +27,8 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include "gpx/Node.h"
-
 
 namespace gpx
 {
@@ -38,7 +38,7 @@ namespace gpx
   /// @brief The string class.
   ///
   
-  class String : public Node
+  class DLL_API String : public Node
   {
     public:
 

--- a/gpx/TRK.h
+++ b/gpx/TRK.h
@@ -27,6 +27,7 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include "gpx/Node.h"
 
 #include "gpx/String_.h"
@@ -45,7 +46,7 @@ namespace gpx
   /// @brief The track class.
   ///
   
-  class TRK : public Node
+  class DLL_API TRK : public Node
   {
     public:
 

--- a/gpx/WPT.h
+++ b/gpx/WPT.h
@@ -27,6 +27,7 @@
 //
 //==============================================================================
 
+#include "gpx/export.h"
 #include "gpx/Node.h"
 
 #include "gpx/String_.h"
@@ -51,7 +52,7 @@ namespace gpx
   /// @brief The waypoint class.
   ///
   
-  class WPT : public Node
+  class DLL_API WPT : public Node
   {
     public:
 

--- a/gpx/Writer.h
+++ b/gpx/Writer.h
@@ -40,7 +40,7 @@ namespace gpx
   /// @brief The xml writer class.
   ///
   
-  class Writer
+  class DLL_API Writer
   {
   public:
 

--- a/gpx/export.h
+++ b/gpx/export.h
@@ -1,0 +1,14 @@
+#ifndef EPXORT_H
+#define EPXORT_H
+
+#if WIN32 && BUILD_SHARED_LIBS
+	#ifdef DLL_EXPORT
+		#define DLL_API __declspec(dllexport)
+	#else
+		#define DLL_API __declspec(dllimport)
+	#endif
+#else
+	#define DLL_API
+#endif
+
+#endif //EPXORT_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,6 @@
-#if(WIN32)
-#  set(EXPAT_FOUND TRUE)
-#  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
-#  set(EXPAT_LIBRARIES    "/Program Files (x86)/Expat 2.2.0/Bin/libexpat")
-  # Copy libexpat.dll and test.gpx to executable directory
-#else()
-  find_package(EXPAT REQUIRED)
-#endif()
+cmake_minimum_required(VERSION 2.8.0)
+
+find_package(EXPAT REQUIRED)
 
 include_directories (. .. ${EXPAT_INCLUDE_DIRS})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,11 @@
-if(WIN32)
-  set(EXPAT_FOUND TRUE)
-  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
-  set(EXPAT_LIBRARIES    "/Program Files (x86)/Expat 2.2.0/Bin/libexpat")
+#if(WIN32)
+#  set(EXPAT_FOUND TRUE)
+#  set(EXPAT_INCLUDE_DIRS "/Program Files (x86)/Expat 2.2.0/Source/lib")
+#  set(EXPAT_LIBRARIES    "/Program Files (x86)/Expat 2.2.0/Bin/libexpat")
   # Copy libexpat.dll and test.gpx to executable directory
-else()
+#else()
   find_package(EXPAT REQUIRED)
-endif()
+#endif()
 
 include_directories (. .. ${EXPAT_INCLUDE_DIRS})
 


### PR DESCRIPTION
Under windows, you can find expat with find_package。
Add compilation examples and test switches。
Cmake uses the BUILD_SHARED_LIBS variable to determine whether to generate a dynamic library。